### PR TITLE
Proposal to remove this code with a db attribute. Why is it necessary?

### DIFF
--- a/app/code/local/Ho/Customer/sql/ho_customer_setup/upgrade-0.2.0-0.3.0.php
+++ b/app/code/local/Ho/Customer/sql/ho_customer_setup/upgrade-0.2.0-0.3.0.php
@@ -4,41 +4,4 @@
 $installer = $this;
 $installer->startSetup();
 
-$attributeCode = 'hear_about_us';
-
-$setup = new Mage_Eav_Model_Entity_Setup('core_setup');
-
-$entityTypeId     = $setup->getEntityTypeId('customer');
-$attributeSetId   = $setup->getDefaultAttributeSetId($entityTypeId);
-$attributeGroupId = $setup->getDefaultAttributeGroupId($entityTypeId, $attributeSetId);
-
-$setup->addAttribute('customer', $attributeCode, array(
-    'label'         => 'How did you hear about us?',
-    'input'         => 'select',
-    'type'          => 'int',
-    'visible'       => 1,
-    'required'      => 0,
-    'user_defined'  => 1,
-    'source'        => 'eav/entity_attribute_source_table',
-    'option'        => array('values' => array(
-        'Friend or acquaintance',
-        'TV',
-        'Radio',
-        'Facebook',
-    )),
-));
-
-$setup->addAttributeToGroup(
-    $entityTypeId,
-    $attributeSetId,
-    $attributeGroupId,
-    $attributeCode,
-    '999'
-);
-
-$oAttribute = Mage::getSingleton('eav/config')->getAttribute('customer', $attributeCode);
-$oAttribute->setData('used_in_forms', array('adminhtml_customer', 'adminhtml_checkout', 'customer_account_edit', 'ho_customer_complete_profile'));
-$oAttribute->setData('sort_order', 300);
-$oAttribute->save();
-
 $setup->endSetup();


### PR DESCRIPTION
Proposal to remove this code with a db attribute. Why is it necessary? and maybe it does not belong to this extension. (it is often seen in checkout extensions)

Looking at the features this should not be added to the extension. I understand the goal is:
- Automatically creates customers from guest order
- better support for the customer increment_id
